### PR TITLE
fix: Sets Theme to Light

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -1,5 +1,7 @@
 @import "tailwindcss";
-@plugin "daisyui";
+@plugin "daisyui" {
+    themes: light --default
+};
 
 :root { 
   scroll-behavior: smooth; 


### PR DESCRIPTION
This pull request updates the way the DaisyUI plugin is configured in the `src/style.css` file. The change specifies the use of the default light theme for DaisyUI.

Styling configuration:

* Updated the DaisyUI plugin configuration to explicitly set the `light` theme as the default. (`src/style.css`)